### PR TITLE
pusher: accept callable relation factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: ruby
 rvm:
   - 2.5
   - 2.4
-before_install:
-  - gem install bundler --version 1.6.4 # keep in sync with BUNDLED WITH version in Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: ruby
 rvm:
   - 2.5
   - 2.4
+before_install:
+  - rvm @default,@global do gem uninstall bundler
+  - gem install bundle --version 1.6.4 # keep in sync with BUNDLED WITH version in Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,4 @@ rvm:
   - 2.5
   - 2.4
 before_install:
-  - rvm @default,@global do gem uninstall bundler
-  - gem install bundle --version 1.6.4 # keep in sync with BUNDLED WITH version in Gemfile.lock
+  - gem install bundler --version 1.6.4 # keep in sync with BUNDLED WITH version in Gemfile.lock

--- a/feedx.gemspec
+++ b/feedx.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'feedx'
-  s.version       = '0.1.0'
+  s.version       = '0.1.1'
   s.authors       = ['Black Square Media Ltd']
   s.email         = ['info@blacksquaremedia.com']
   s.summary       = %(Exchange data between components via feeds)

--- a/spec/feedx/pusher_spec.rb
+++ b/spec/feedx/pusher_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Feedx::Pusher do
     end.to raise_error(/unable to detect format/)
   end
 
+  it 'should accept callable relation factory' do
+    calls = 0
+
+    pusher = described_class.new -> {
+      calls += 1
+      relation
+    }, "file://#{tempdir}/file.json"
+
+    expect { pusher.perform }.to change{ calls }.from(0).to(1)
+    expect { pusher.perform }.to change{ calls }.from(1).to(2)
+  end
+
   it 'should push compressed JSON' do
     pusher = described_class.new relation, "file://#{tempdir}/file.jsonz"
     size   = pusher.perform


### PR DESCRIPTION
Sometimes, it's nice to have simple scoped relations, which should be "rebuilt" on every push, like:

```ruby
Feedx::Pusher.new(
  -> { Model.where(Model.arel_table[:created_at].gteq(1.hour.ago)) },
  "file.pbz",
)
```

If you'd pass this relation directly, the `where` argument would be "frozen" and after a day it would return not an hour-old entities, but a day-old ones.