### PR TITLE
Feature/lowercase meta last modified

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    feedx (0.3.0)
-      bfs (>= 0.3.3)
+    feedx (0.3.1)
+      bfs (>= 0.3.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    bfs (0.3.3)
+    bfs (0.3.4)
     diff-lcs (1.3)
     google-protobuf (3.6.1)
     jaro_winkler (1.5.1)

--- a/feedx.gemspec
+++ b/feedx.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'feedx'
-  s.version       = '0.3.0'
+  s.version       = '0.3.1'
   s.authors       = ['Black Square Media Ltd']
   s.email         = ['info@blacksquaremedia.com']
   s.summary       = %(Exchange data between components via feeds)
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.2'
 
-  s.add_dependency 'bfs', '>= 0.3.3'
+  s.add_dependency 'bfs', '>= 0.3.4'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'pbio'

--- a/lib/feedx/pusher.rb
+++ b/lib/feedx/pusher.rb
@@ -4,7 +4,7 @@ require 'bfs'
 module Feedx
   # Pushes a relation as a protobuf encoded stream to an S3 location.
   class Pusher
-    META_LAST_MODIFIED = 'X-Feedx-Pusher-Last-Modified'.freeze
+    META_LAST_MODIFIED = 'x-feedx-pusher-last-modified'.freeze
 
     # See constructor.
     def self.perform(url, opts={}, &block)

--- a/spec/feedx/pusher_spec.rb
+++ b/spec/feedx/pusher_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Feedx::Pusher do
 
   it 'should support last-modified' do
     described_class.perform 'mock:///dir/file.json', last_modified: Time.at(1515151515), enum: enumerable
-    expect(bucket.info('dir/file.json').metadata).to eq('X-Feedx-Pusher-Last-Modified' => '1515151515000')
+    expect(bucket.info('dir/file.json').metadata).to eq('x-feedx-pusher-last-modified' => '1515151515000')
   end
 
   it 'should perform conditionally' do


### PR DESCRIPTION
At least S3 lowercases meta keys.

Though haven't tested with GCS, but I think it should be safe (if not the same force-lowercasing as well).

Bumped only MINOR version because I'd consider bfs meta key being temporary data.