### PR TITLE
writer: ignore "context canceled" error on Discard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ matrix:
   include:
     - language: ruby
       rvm:
+        - 2.7
+      before_install:
+        - gem install bundler
+    - language: ruby
+      rvm:
         - 2.6
       before_install:
         - gem install bundler
@@ -13,10 +18,5 @@ matrix:
     - language: go
       go:
         - 1.13.x
-      env:
-        - GO111MODULE=on
-    - language: go
-      go:
-        - 1.12.x
       env:
         - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ matrix:
   include:
     - language: ruby
       rvm:
-        - 2.7
-      before_install:
-        - gem install bundler
-    - language: ruby
-      rvm:
         - 2.6
       before_install:
         - gem install bundler

--- a/lib/feedx/consumer.rb
+++ b/lib/feedx/consumer.rb
@@ -8,7 +8,7 @@ module Feedx
     include Enumerable
 
     # See constructor.
-    def self.each(url, klass, opts={}, &block)
+    def self.each(url, klass, opts = {}, &block)
       new(url, klass, opts).each(&block)
     end
 
@@ -19,7 +19,7 @@ module Feedx
     # @option opts [Hash] :format_options format decode options. Default: {}.
     # @option opts [Symbol,Class<Feedx::Compression::Abstract>] :compress enable compression. Default: from file extension.
     # @option opts [Feedx::Cache::Value] :cache cache value to store remote last modified time and consume conditionally.
-    def initialize(url, klass, opts={})
+    def initialize(url, klass, opts = {})
       @klass    = klass
       @stream   = Feedx::Stream.new(url, opts)
       @fmt_opts = opts[:format_options] || {}

--- a/lib/feedx/producer.rb
+++ b/lib/feedx/producer.rb
@@ -6,7 +6,7 @@ module Feedx
   # Produces a relation as an encoded feed to a remote location.
   class Producer
     # See constructor.
-    def self.perform(url, opts={}, &block)
+    def self.perform(url, opts = {}, &block)
       new(url, opts, &block).perform
     end
 
@@ -19,7 +19,7 @@ module Feedx
     # @option opts [Time,Proc] :last_modified the last modified time, used to determine if a push is necessary.
     # @yield A block factory to generate the relation or enumerator.
     # @yieldreturn [Enumerable,ActiveRecord::Relation] the relation or enumerator to stream.
-    def initialize(url, opts={}, &block)
+    def initialize(url, opts = {}, &block)
       @enum = opts[:enum] || block
       raise ArgumentError, "#{self.class.name}.new expects an :enum option or a block factory" unless @enum
 

--- a/lib/feedx/stream.rb
+++ b/lib/feedx/stream.rb
@@ -10,7 +10,7 @@ module Feedx
     # @param [Hash] opts options
     # @option opts [Symbol,Class<Feedx::Format::Abstract>] :format custom formatter. Default: from file extension.
     # @option opts [Symbol,Class<Feedx::Compression::Abstract>] :compress enable compression. Default: from file extension.
-    def initialize(url, opts={})
+    def initialize(url, opts = {})
       @blob     = BFS::Blob.new(url)
       @format   = detect_format(opts[:format])
       @compress = detect_compress(opts[:compress])
@@ -20,7 +20,7 @@ module Feedx
     # @param [Hash] opts BFS::Blob#open options
     # @yield A block over a formatted stream.
     # @yieldparam [Feedx::Format::Abstract] formatted input stream.
-    def open(opts={})
+    def open(opts = {})
       @blob.open(opts) do |io|
         @compress.reader(io) do |cio|
           fmt = @format.new(cio)
@@ -33,7 +33,7 @@ module Feedx
     # @param [Hash] opts BFS::Blob#create options
     # @yield A block over a formatted stream.
     # @yieldparam [Feedx::Format::Abstract] formatted output stream.
-    def create(opts={})
+    def create(opts = {})
       @blob.create(opts) do |io|
         @compress.writer(io) do |cio|
           fmt = @format.new(cio)

--- a/spec/feedx/consumer_spec.rb
+++ b/spec/feedx/consumer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Feedx::Consumer do
 
   private
 
-  def mock_produce!(opts={})
+  def mock_produce!(opts = {})
     url = 'mock:///dir/file.json'
     opts[:enum] ||= %w[x y z].map {|t| Feedx::TestCase::Model.new(t) } * 100
     Feedx::Producer.perform url, opts

--- a/writer.go
+++ b/writer.go
@@ -3,7 +3,7 @@ package feedx
 import (
 	"bufio"
 	"context"
-  "errors"
+	"errors"
 	"io"
 	"time"
 
@@ -115,10 +115,10 @@ func (w *Writer) NumWritten() int {
 // Discard closes the writer and discards the contents.
 func (w *Writer) Discard() error {
 	w.cancel()
-  if err := w.Commit(); err != nil && !errors.Is(err, context.Canceled) {
-    return err
-  }
-  return nil
+	if err := w.Commit(); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	return nil
 }
 
 // Commit closes the writer and persists the contents.

--- a/writer.go
+++ b/writer.go
@@ -3,6 +3,7 @@ package feedx
 import (
 	"bufio"
 	"context"
+  "errors"
 	"io"
 	"time"
 
@@ -114,7 +115,10 @@ func (w *Writer) NumWritten() int {
 // Discard closes the writer and discards the contents.
 func (w *Writer) Discard() error {
 	w.cancel()
-	return w.Commit()
+  if err := w.Commit(); err != nil && !errors.Is(err, context.Canceled) {
+    return err
+  }
+  return nil
 }
 
 // Commit closes the writer and persists the contents.


### PR DESCRIPTION
It is expected on Discard, as context is canceled first and then few Close-s are attempted.