### PR TITLE
Propagate options correctly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,5 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: "2.4"
+Metrics/ParameterLists:
+  Max: 10

--- a/lib/feedx/cache/abstract.rb
+++ b/lib/feedx/cache/abstract.rb
@@ -5,12 +5,12 @@ class Feedx::Cache::Abstract
   end
 
   # Read reads a key.
-  def read(_key, **_opts)
+  def read(_key, **)
     raise 'Not implemented'
   end
 
   # Write writes a key/value pair.
-  def write(_key, _value, **_opts)
+  def write(_key, _value, **)
     raise 'Not implemented'
   end
 

--- a/lib/feedx/compression/abstract.rb
+++ b/lib/feedx/compression/abstract.rb
@@ -1,9 +1,9 @@
 class Feedx::Compression::Abstract
-  def reader(_io, &_block)
+  def reader(_io, **, &_block)
     raise 'Not implemented'
   end
 
-  def writer(_io, &_block)
+  def writer(_io, **, &_block)
     raise 'Not implemented'
   end
 end

--- a/lib/feedx/compression/gzip.rb
+++ b/lib/feedx/compression/gzip.rb
@@ -1,12 +1,12 @@
 require 'zlib'
 
 class Feedx::Compression::Gzip < Feedx::Compression::Abstract
-  def reader(io, &block)
+  def reader(io, **, &block)
     force_binmode(io)
     Zlib::GzipReader.wrap(io, &block)
   end
 
-  def writer(io, &block)
+  def writer(io, **, &block)
     force_binmode(io)
     Zlib::GzipWriter.wrap(io, &block)
   end

--- a/lib/feedx/compression/none.rb
+++ b/lib/feedx/compression/none.rb
@@ -1,9 +1,9 @@
 class Feedx::Compression::None < Feedx::Compression::Abstract
-  def reader(io)
+  def reader(io, **)
     yield(io)
   end
 
-  def writer(io)
+  def writer(io, **)
     yield(io)
   end
 end

--- a/lib/feedx/consumer.rb
+++ b/lib/feedx/consumer.rb
@@ -40,7 +40,7 @@ module Feedx
         return false if remote_rev.positive? && remote_rev <= local_rev
       end
 
-      @stream.open(**@opts) do |fmt|
+      @stream.open do |fmt|
         fmt.decode_each(@klass, **@opts, &block)
       end
       @cache.write(remote_rev) if @cache && remote_rev

--- a/lib/feedx/format.rb
+++ b/lib/feedx/format.rb
@@ -39,6 +39,9 @@ module Feedx
       def registry
         @registry ||= {
           'json'     => :JSON,
+          'jsonl'    => :JSON,
+          'ndjson'   => :JSON,
+          'parquet'  => :Parquet,
           'pb'       => :Protobuf,
           'proto'    => :Protobuf,
           'protobuf' => :Protobuf,

--- a/lib/feedx/producer.rb
+++ b/lib/feedx/producer.rb
@@ -44,7 +44,7 @@ module Feedx
         nil
       end if local_rev.positive?
 
-      @stream.create metadata: { META_LAST_MODIFIED => local_rev.to_s }, **@opts do |fmt|
+      @stream.create metadata: { META_LAST_MODIFIED => local_rev.to_s } do |fmt|
         iter = enum.respond_to?(:find_each) ? :find_each : :each
         enum.send(iter) {|rec| fmt.encode(rec, **@opts) }
       end

--- a/lib/feedx/stream.rb
+++ b/lib/feedx/stream.rb
@@ -23,8 +23,8 @@ module Feedx
     # @yieldparam [Feedx::Format::Abstract] formatted input stream.
     def open(**opts)
       @blob.open(**opts) do |io|
-        @compress.reader(io, **@opts, **opts) do |cio|
-          @format.decoder(cio, **@opts, **opts) do |fmt|
+        @compress.reader(io, **@opts) do |cio|
+          @format.decoder(cio, **@opts) do |fmt|
             yield fmt
           end
         end
@@ -37,8 +37,8 @@ module Feedx
     # @yieldparam [Feedx::Format::Abstract] formatted output stream.
     def create(**opts)
       @blob.create(**opts) do |io|
-        @compress.writer(io, **@opts, **opts) do |cio|
-          @format.encoder(cio, **@opts, **opts) do |fmt|
+        @compress.writer(io, **@opts) do |cio|
+          @format.encoder(cio, **@opts) do |fmt|
             yield fmt
           end
         end

--- a/lib/feedx/stream.rb
+++ b/lib/feedx/stream.rb
@@ -22,7 +22,7 @@ module Feedx
     # @yield A block over a formatted stream.
     # @yieldparam [Feedx::Format::Abstract] formatted input stream.
     def open(**opts)
-      @blob.open(**@opts, **opts) do |io|
+      @blob.open(**opts) do |io|
         @compress.reader(io, **@opts, **opts) do |cio|
           @format.decoder(cio, **@opts, **opts) do |fmt|
             yield fmt
@@ -36,7 +36,7 @@ module Feedx
     # @yield A block over a formatted stream.
     # @yieldparam [Feedx::Format::Abstract] formatted output stream.
     def create(**opts)
-      @blob.create(**@opts, **opts) do |io|
+      @blob.create(**opts) do |io|
         @compress.writer(io, **@opts, **opts) do |cio|
           @format.encoder(cio, **@opts, **opts) do |fmt|
             yield fmt

--- a/spec/feedx/producer_spec.rb
+++ b/spec/feedx/producer_spec.rb
@@ -64,4 +64,10 @@ RSpec.describe Feedx::Producer do
     size = described_class.perform 'mock:///dir/file.json', last_modified: Time.at(1515151516), enum: enumerable
     expect(size).to eq(15900)
   end
+
+  it 'should accept downstream options' do
+    expect do
+      described_class.perform 'mock:///dir/file.jsonz', enum: enumerable, x: 1, y: 'v', z: true
+    end.not_to raise_error
+  end
 end


### PR DESCRIPTION
This version is an attempt to consistently propagate options to all downstream receivers. At the same time I deprecated `format_options`. 

I am not 100% sure it plays well with all the underlying BFS adapters, so could you please test this SHA with some of our staging apps before I merge it?