### PR TITLE
compression: flate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.go,Makefile]
+[{*.go,Makefile}]
 indent_style = tab

--- a/compression.go
+++ b/compression.go
@@ -1,6 +1,7 @@
 package feedx
 
 import (
+	"compress/flate"
 	"compress/gzip"
 	"io"
 	"path"
@@ -20,6 +21,8 @@ func DetectCompression(name string) Compression {
 		ext := path.Ext(path.Base(name))
 		if ext != "" && ext[0] == '.' && ext[len(ext)-1] == 'z' {
 			return GZipCompression
+		} else if ext == ".flate" {
+			return FlateCompression
 		}
 	}
 	return NoCompression
@@ -60,4 +63,19 @@ func (gzipCompression) NewReader(r io.Reader) (io.ReadCloser, error) {
 
 func (gzipCompression) NewWriter(w io.Writer) (io.WriteCloser, error) {
 	return gzip.NewWriter(w), nil
+}
+
+// --------------------------------------------------------------------
+
+// FlateCompression supports flate compression format.
+var FlateCompression = flateCompression{}
+
+type flateCompression struct{}
+
+func (flateCompression) NewReader(r io.Reader) (io.ReadCloser, error) {
+	return flate.NewReader(r), nil
+}
+
+func (flateCompression) NewWriter(w io.Writer) (io.WriteCloser, error) {
+	return flate.NewWriter(w, flate.BestSpeed)
 }

--- a/compression_test.go
+++ b/compression_test.go
@@ -41,6 +41,9 @@ var _ = Describe("Compression", func() {
 		Expect(feedx.DetectCompression("/path/to/file.pb.gz")).To(Equal(feedx.GZipCompression))
 		Expect(feedx.DetectCompression("/path/to/file.pbz")).To(Equal(feedx.GZipCompression))
 
+		Expect(feedx.DetectCompression("/path/to/file.flate")).To(Equal(feedx.FlateCompression))
+		Expect(feedx.DetectCompression("/path/to/file.whatever.flate")).To(Equal(feedx.FlateCompression))
+
 		Expect(feedx.DetectCompression("")).To(Equal(feedx.NoCompression))
 		Expect(feedx.DetectCompression("/path/to/file")).To(Equal(feedx.NoCompression))
 		Expect(feedx.DetectCompression("/path/to/file.txt")).To(Equal(feedx.NoCompression))
@@ -57,6 +60,15 @@ var _ = Describe("Compression", func() {
 
 	Describe("GZipCompression", func() {
 		var subject = feedx.GZipCompression
+		var _ feedx.Compression = subject
+
+		It("should write/read", func() {
+			runSharedTest(subject)
+		})
+	})
+
+	Describe("FlateCompression", func() {
+		var subject = feedx.FlateCompression
 		var _ feedx.Compression = subject
 
 		It("should write/read", func() {

--- a/format_test.go
+++ b/format_test.go
@@ -43,10 +43,12 @@ var _ = Describe("Format", func() {
 	It("should detect the format", func() {
 		Expect(feedx.DetectFormat("/path/to/file.json")).To(Equal(feedx.JSONFormat))
 		Expect(feedx.DetectFormat("/path/to/file.json.gz")).To(Equal(feedx.JSONFormat))
+		Expect(feedx.DetectFormat("/path/to/file.json.flate")).To(Equal(feedx.JSONFormat))
 		Expect(feedx.DetectFormat("/path/to/file.jsonz")).To(Equal(feedx.JSONFormat))
 
 		Expect(feedx.DetectFormat("/path/to/file.pb")).To(Equal(feedx.ProtobufFormat))
 		Expect(feedx.DetectFormat("/path/to/file.pb.gz")).To(Equal(feedx.ProtobufFormat))
+		Expect(feedx.DetectFormat("/path/to/file.pb.flate")).To(Equal(feedx.ProtobufFormat))
 		Expect(feedx.DetectFormat("/path/to/file.pbz")).To(Equal(feedx.ProtobufFormat))
 
 		Expect(feedx.DetectFormat("")).To(BeNil())


### PR DESCRIPTION
There's no ruby (de)flate counterpart - it's slightly more tricky than Go:

- need to implement own reader/writer
- writer should be easy
- but reader - not sure, maybe read in blocks (of length 0..MAXLEN) and deflate each block and then "proxy" each block (with smth like StringIO or so)?