### PR TITLE
Feature/parquet encoder

### DIFF
--- a/ext/parquet/encoder.go
+++ b/ext/parquet/encoder.go
@@ -5,32 +5,15 @@ import (
 
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/floor"
-	fparquet "github.com/fraugster/parquet-go/parquet"
-	"github.com/fraugster/parquet-go/parquetschema"
 )
 
 type encoder struct {
 	fw *floor.Writer
 }
 
-func newEncoder(w io.Writer, opts *EncoderOpts) (*encoder, error) {
-	// determine compression
-	cp, err := fparquet.CompressionCodecFromString(opts.Compression)
-	if err != nil {
-		return nil, err
-	}
-
-	// parse the schema def
-	sd, err := parquetschema.ParseSchemaDefinition(opts.SchemaDef)
-	if err != nil {
-		return nil, err
-	}
-
+func newEncoder(w io.Writer, opts []goparquet.FileWriterOption) (*encoder, error) {
 	// create the writer
-	pw := goparquet.NewFileWriter(w,
-		goparquet.WithCompressionCodec(cp),
-		goparquet.WithSchemaDefinition(sd),
-	)
+	pw := goparquet.NewFileWriter(w, opts...)
 
 	return &encoder{
 		// wrap the parquet writer with a floor writer

--- a/ext/parquet/encoder.go
+++ b/ext/parquet/encoder.go
@@ -1,49 +1,49 @@
 package parquet
 
 import (
-	"fmt"
 	"io"
 
 	goparquet "github.com/fraugster/parquet-go"
+	"github.com/fraugster/parquet-go/floor"
 	fparquet "github.com/fraugster/parquet-go/parquet"
 	"github.com/fraugster/parquet-go/parquetschema"
 )
 
 type encoder struct {
-	fw *goparquet.FileWriter
+	fw *floor.Writer
 }
 
 func newEncoder(w io.Writer, opts *EncoderOpts) (*encoder, error) {
 	// determine compression
-	comp, err := fparquet.CompressionCodecFromString(opts.Compression)
+	cp, err := fparquet.CompressionCodecFromString(opts.Compression)
 	if err != nil {
 		return nil, err
 	}
 
 	// parse the schema def
-	schemaDef, err := parquetschema.ParseSchemaDefinition(opts.SchemaDef)
+	sd, err := parquetschema.ParseSchemaDefinition(opts.SchemaDef)
 	if err != nil {
 		return nil, err
 	}
 
 	// create the writer
-	fw := goparquet.NewFileWriter(w,
-		goparquet.WithCompressionCodec(comp),
-		goparquet.WithSchemaDefinition(schemaDef),
-		goparquet.WithCreator("write-lowlevel"),
+	pw := goparquet.NewFileWriter(w,
+		goparquet.WithCompressionCodec(cp),
+		goparquet.WithSchemaDefinition(sd),
 	)
 
-	return &encoder{fw: fw}, nil
+	return &encoder{
+		// wrap the parquet writer with a floor writer
+		fw: floor.NewWriter(pw),
+	}, nil
 }
 
+// implements feedx.FormatEncoder
 func (w encoder) Encode(v interface{}) error {
-	val, ok := v.(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("feedx: value %v is not a map[string]interface{}", v)
-	}
-	return w.fw.AddData(val)
+	return w.fw.Write(v)
 }
 
+// implements feedx.FormatEncoder
 func (w encoder) Close() error {
 	return w.fw.Close()
 }

--- a/ext/parquet/encoder.go
+++ b/ext/parquet/encoder.go
@@ -8,7 +8,7 @@ import (
 )
 
 type encoder struct {
-	fw *floor.Writer
+	*floor.Writer
 }
 
 func newEncoder(w io.Writer, opts []goparquet.FileWriterOption) (*encoder, error) {
@@ -17,16 +17,11 @@ func newEncoder(w io.Writer, opts []goparquet.FileWriterOption) (*encoder, error
 
 	return &encoder{
 		// wrap the parquet writer with a floor writer
-		fw: floor.NewWriter(pw),
+		Writer: floor.NewWriter(pw),
 	}, nil
 }
 
 // implements feedx.FormatEncoder
-func (w encoder) Encode(v interface{}) error {
-	return w.fw.Write(v)
-}
-
-// implements feedx.FormatEncoder
-func (w encoder) Close() error {
-	return w.fw.Close()
+func (w *encoder) Encode(v interface{}) error {
+	return w.Writer.Write(v)
 }

--- a/ext/parquet/encoder.go
+++ b/ext/parquet/encoder.go
@@ -1,0 +1,49 @@
+package parquet
+
+import (
+	"fmt"
+	"io"
+
+	goparquet "github.com/fraugster/parquet-go"
+	fparquet "github.com/fraugster/parquet-go/parquet"
+	"github.com/fraugster/parquet-go/parquetschema"
+)
+
+type encoder struct {
+	fw *goparquet.FileWriter
+}
+
+func newEncoder(w io.Writer, opts *EncoderOpts) (*encoder, error) {
+	// determine compression
+	comp, err := fparquet.CompressionCodecFromString(opts.Compression)
+	if err != nil {
+		return nil, err
+	}
+
+	// parse the schema def
+	schemaDef, err := parquetschema.ParseSchemaDefinition(opts.SchemaDef)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the writer
+	fw := goparquet.NewFileWriter(w,
+		goparquet.WithCompressionCodec(comp),
+		goparquet.WithSchemaDefinition(schemaDef),
+		goparquet.WithCreator("write-lowlevel"),
+	)
+
+	return &encoder{fw: fw}, nil
+}
+
+func (w encoder) Encode(v interface{}) error {
+	val, ok := v.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("feedx: value %v is not a map[string]interface{}", v)
+	}
+	return w.fw.AddData(val)
+}
+
+func (w encoder) Close() error {
+	return w.fw.Close()
+}

--- a/ext/parquet/encoder_test.go
+++ b/ext/parquet/encoder_test.go
@@ -1,0 +1,45 @@
+package parquet_test
+
+import (
+	"bytes"
+
+	"github.com/bsm/feedx"
+	"github.com/bsm/feedx/ext/parquet"
+	. "github.com/bsm/ginkgo"
+	. "github.com/bsm/gomega"
+)
+
+var _ = Describe("Decoder", func() {
+	var subject feedx.FormatEncoder
+
+	BeforeEach(func() {
+		var err error
+		buf := new(bytes.Buffer)
+		format := &parquet.Format{
+			EncoderOpts: &parquet.EncoderOpts{
+				SchemaDef: `message stat {
+					required int64 id;
+					required binary city (STRING);
+					optional int64 population;
+				}`,
+			},
+		}
+		subject, err = format.NewEncoder(buf)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("encodes", func() {
+		v1 := map[string]interface{}{"id": int64(1), "city": []byte("London"), "population": int64(8982000)}
+		Expect(subject.Encode(v1)).To(Succeed())
+
+		v2 := map[string]interface{}{"id": int64(2), "city": []byte("Berlin"), "population": int64(3645000)}
+		Expect(subject.Encode(v2)).To(Succeed())
+
+		Expect(subject.Encode("abc")).NotTo(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(subject.Close()).To(Succeed())
+	})
+
+})

--- a/ext/parquet/encoder_test.go
+++ b/ext/parquet/encoder_test.go
@@ -2,6 +2,7 @@ package parquet_test
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/bsm/feedx"
 	"github.com/bsm/feedx/ext/parquet"
@@ -21,6 +22,7 @@ var _ = Describe("Decoder", func() {
 					required int64 id;
 					required binary city (STRING);
 					optional int64 population;
+					optional int64 ts (TIMESTAMP(NANOS, true));
 				}`,
 			},
 		}
@@ -29,7 +31,7 @@ var _ = Describe("Decoder", func() {
 	})
 
 	It("encodes", func() {
-		v1 := map[string]interface{}{"id": int64(1), "city": []byte("London"), "population": int64(8982000)}
+		v1 := map[string]interface{}{"id": int64(1), "city": []byte("London"), "population": int64(8982000), "ts": time.Now().UnixNano()}
 		Expect(subject.Encode(v1)).To(Succeed())
 
 		v2 := map[string]interface{}{"id": int64(2), "city": []byte("Berlin"), "population": int64(3645000)}

--- a/ext/parquet/parquet.go
+++ b/ext/parquet/parquet.go
@@ -1,37 +1,19 @@
 package parquet
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
 	"github.com/bsm/feedx"
+	goparquet "github.com/fraugster/parquet-go"
 )
-
-type EncoderOpts struct {
-	SchemaDef   string
-	Compression string // compession string from github.com/fraugster/parquet-go
-}
-
-func (o *EncoderOpts) norm() error {
-	if o.SchemaDef == "" {
-		return fmt.Errorf("SchemaDef is missing")
-	}
-
-	if o.Compression == "" {
-		o.Compression = "SNAPPY"
-	}
-
-	return nil
-}
 
 // --------------------------------------------------------------------
 
 // Format is a parquet format.
 type Format struct {
-	TempDir     string
-	EncoderOpts *EncoderOpts
+	TempDir string
 }
 
 // NewDecoder implements Format.
@@ -55,13 +37,8 @@ func (f *Format) NewDecoder(r io.Reader) (feedx.FormatDecoder, error) {
 }
 
 // NewEncoder implements Format.
-func (f *Format) NewEncoder(w io.Writer) (feedx.FormatEncoder, error) {
-	// check options
-	if err := f.EncoderOpts.norm(); err != nil {
-		return nil, err
-	}
-
-	return newEncoder(w, f.EncoderOpts)
+func (f *Format) NewEncoder(w io.Writer, opts ...goparquet.FileWriterOption) (feedx.FormatEncoder, error) {
+	return newEncoder(w, opts)
 }
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
Very basic parquet writer. I just wanted to wrap `fraugster/parquet-go` as much as possible. Passing the schema in as an options is a bit faffy BUT i think it's the simplest way.  

As with reading the floor writer doesn't support int96. 