### PR TITLE
gemspec: skip ruby version 0.13.0, jump right to 0.13.1 to keep Go/Ruby versioning aligned

### DIFF
--- a/feedx.gemspec
+++ b/feedx.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'feedx'
-  s.version       = '0.13.0'
+  s.version       = '0.13.1'
   s.authors       = ['Black Square Media Ltd']
   s.email         = ['info@blacksquaremedia.com']
   s.summary       = %(Exchange data between components via feeds)


### PR DESCRIPTION
Ruby 0.13.0 was never released.

But v0.13.0 Git tag was created (old one).

So skipping v0.13.0 version for ruby to keep them synced between ruby and go.